### PR TITLE
Allow Opening Notebooks from JupyterLab using SwanGallery Extension

### DIFF
--- a/mkdocs_swan/main.html
+++ b/mkdocs_swan/main.html
@@ -5,14 +5,25 @@
 {{ super() }}
 <script type="text/javascript">
     if ( window !== window.parent ) {
-        // The page is in an iframe, open external links in a new tab
+        // The page is in an iframe
         window.addEventListener("DOMContentLoaded", function externalLinks() {
             var anchors = document.getElementsByTagName("a");
             for (var i = 0; i < anchors.length; i++) {
                     if (anchors[i].hostname !== window.location.hostname) {
                         anchors[i].setAttribute("target", "_blank");
                         anchors[i].setAttribute("rel", "noopener");
-                }
+                    }
+                    // Handle 'Open in SWAN' badges in the parent JupyterLab window
+                    if (anchors[i].hostname == 'cern.ch' && anchors[i].pathname == '/swanserver/cgi-bin/go') {
+                        const projectUrl = new URLSearchParams(anchors[i].search).get('projurl');
+                        if (projectUrl) {
+                                anchors[i].onclick = () => {
+                                window.parent.postMessage(projectUrl,'*');
+                                //  Skip redirecting the iframe page to the link 
+                                return false;
+                            }
+                        }
+                    }
             }
         }); 
     }

--- a/mkdocs_swan/main.html
+++ b/mkdocs_swan/main.html
@@ -1,6 +1,24 @@
 
 {% extends "base.html" %}
 
+{% block extrahead %}
+{{ super() }}
+<script type="text/javascript">
+    if ( window !== window.parent ) {
+        // The page is in an iframe, open external links in a new tab
+        window.addEventListener("DOMContentLoaded", function externalLinks() {
+            var anchors = document.getElementsByTagName("a");
+            for (var i = 0; i < anchors.length; i++) {
+                    if (anchors[i].hostname !== window.location.hostname) {
+                        anchors[i].setAttribute("target", "_blank");
+                        anchors[i].setAttribute("rel", "noopener");
+                }
+            }
+        }); 
+    }
+</script>
+{% endblock %}
+
 {% block styles %}
 {{ super() }}
 <link rel="stylesheet" type="text/css" href="{{ 'css/style.css' | url }}" />

--- a/mkdocs_swan/notebook.html
+++ b/mkdocs_swan/notebook.html
@@ -1,17 +1,23 @@
-<script type="text/javascript">
-    function openInSwan(){
-        if ( window.location !== window.parent.location ) {
-            window.parent.postMessage('{{config.gallery_url + page.meta.notebook_url | url}}','https://swan-qa001.cern.ch');
-        } else {
-            window.open("{{ config.open_in_swan_url }}{{  config.gallery_url + page.meta.notebook_url | urlencode }}");
-        }
-    }
-</script>
-
 {% extends "full_width.html" %}
 
 <!-- Add Jupyter basic javascript at the head of the file -->
 {% block extrahead %}
+
+<script type="text/javascript">
+    function openInSwan(){
+        if ( window.location !== window.parent.location ) { // Check if inside an iframe in jupyterlab
+            // If yes, send a message to the jupyterlab frontend extension 
+            // to download the notebook inside the same session
+            window.parent.postMessage('{{ config.gallery_url + page.meta.notebook_url | url }}','*');
+            // Skip redirecting the iframe page to start a new session inside the iframe
+            return false; 
+        } else {
+            // When not inside an iframe, continue redirecting to the href URL to start a new SWAN session
+            return true;
+        }
+    }
+</script>
+
 {{ super() }}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
@@ -32,7 +38,7 @@
             {{ page.meta.notebook_name }} 
             
             {% if page.meta.notebook_url %}
-            <a id="openInSWAN" onclick="openInSwan()" title="Open in SWAN" class="md-content__button md-icon">
+            <a href="{{ config.open_in_swan_url }}{{  config.gallery_url + page.meta.notebook_url | urlencode }}" id="openInSWAN" onclick="return openInSwan()" title="Open in SWAN" class="md-content__button md-icon">
                                         {% include ".icons/material/pencil.svg" %}
                             <span class="button__text">Open in SWAN</span>
                         </a>

--- a/mkdocs_swan/notebook.html
+++ b/mkdocs_swan/notebook.html
@@ -2,7 +2,7 @@
 
 <!-- Add Jupyter basic javascript at the head of the file -->
 {% block extrahead %}
-
+{{ super() }}
 <script type="text/javascript">
     function openInSwan(){
         if ( window.location !== window.parent.location ) { // Check if inside an iframe in jupyterlab

--- a/mkdocs_swan/notebook.html
+++ b/mkdocs_swan/notebook.html
@@ -1,4 +1,14 @@
- {% extends "full_width.html" %}
+<script type="text/javascript">
+    function openInSwan(){
+        if ( window.location !== window.parent.location ) {
+            window.parent.postMessage('{{config.gallery_url + page.meta.notebook_url | url}}','https://swan-qa001.cern.ch');
+        } else {
+            window.open("{{ config.open_in_swan_url }}{{  config.gallery_url + page.meta.notebook_url | urlencode }}");
+        }
+    }
+</script>
+
+{% extends "full_width.html" %}
 
 <!-- Add Jupyter basic javascript at the head of the file -->
 {% block extrahead %}
@@ -12,6 +22,7 @@
 <link rel="stylesheet" type="text/css" href="{{ 'css/notebook.css' | url }}" />
 {% endblock %} 
 
+
 {% if page and page.meta and page.meta.notebook_name %} 
     {% set _ = page.meta.__setitem__("title", page.meta.notebook_name) %} 
 
@@ -21,8 +32,8 @@
             {{ page.meta.notebook_name }} 
             
             {% if page.meta.notebook_url %}
-            <a href="{{ config.open_in_swan_url }}{{  config.gallery_url + page.meta.notebook_url | urlencode }}" title="Open in SWAN" class="md-content__button md-icon">
-                            {% include ".icons/material/pencil.svg" %}
+            <a id="openInSWAN" onclick="openInSwan()" title="Open in SWAN" class="md-content__button md-icon">
+                                        {% include ".icons/material/pencil.svg" %}
                             <span class="button__text">Open in SWAN</span>
                         </a>
             <a href="{{ page.meta.notebook_url }}" title="Download" class="md-content__button md-icon">

--- a/mkdocs_swan/notebook.html
+++ b/mkdocs_swan/notebook.html
@@ -42,7 +42,7 @@
                                         {% include ".icons/material/pencil.svg" %}
                             <span class="button__text">Open in SWAN</span>
                         </a>
-            <a href="{{ page.meta.notebook_url }}" title="Download" class="md-content__button md-icon">
+            <a download href="{{ page.meta.notebook_url }}" title="Download" class="md-content__button md-icon">
                             {% include ".icons/material/download.svg" %}
                             <span class="button__text">Download</span>
                         </a> 

--- a/mkdocs_swan/partials/footer.html
+++ b/mkdocs_swan/partials/footer.html
@@ -84,7 +84,7 @@
   <div class="md-footer-meta md-typeset">
     <div class="md-footer-meta__inner md-grid">
         <div class=" text">
-            <p>SWAN © Copyright CERN 2016-2020. All rights reserved.</p>
+            <p>SWAN © Copyright CERN 2016-{{ build_date_utc.strftime('%Y') }}. All rights reserved.</p>
             <ul>
                 <li><a target="_blank" href="https://cern.ch/swan/">Home</a></li>
                 <li><a target="_blank" href="https://cern.ch/swan-community/">Community</a></li>


### PR DESCRIPTION
Continuation of work done in https://github.com/swan-cern/mkdocs-swan/pull/1

- Preserve href tags in links, but use javascript to disable the behaviour inside an iframe
- Remove target origin when sending a message to parent window, to allow multiple domains
- Add download attribute to <a> tag so that browser does not open the JSON instead of downloading the notebook
- Set target=_blank for all external links using js when opened in an iframe to prevent them from opening inside the iframe
- Make copyright message dynamic